### PR TITLE
portable way to get terminal size

### DIFF
--- a/cursedtag
+++ b/cursedtag
@@ -117,7 +117,9 @@ declare resized
 
 ## Helper functions for TUI
 get_term_size() {
-    eval "$(resize)"
+    size=$(stty size)
+    LINES=${size% *}
+    COLUMNS=${size#* }
 
     # Get max items that fit in the scroll area, leaving first row reserved for header.
     max_items=$((${LINES%% *} - 1))


### PR DESCRIPTION
fixed for myself and tested in iTerm3, bash4.4, macos 10.14.
macos does not have `resize` command.
`stty size` approach looks more portable.
